### PR TITLE
Time not updated after .val()

### DIFF
--- a/tests/timepicker-core-test.js
+++ b/tests/timepicker-core-test.js
@@ -286,6 +286,9 @@ $.fn.timepicker.test = function() {
 
         date = new Date(0,0,0,13,20,0);
         ok(instance.getTime().toLocaleTimeString() == date.toLocaleTimeString(), 'getTime return the time set by setTime using a string.');
+
+        date = new Date(0,0,0,14,30,0);
+        ok(element.val('2:30 PM').timepicker('getTime').toLocaleTimeString() == date.toLocaleTimeString(), 'getTime return the time set by jQuery.fn.val.');
     });
 
     test('option', function() {


### PR DESCRIPTION
Calling `.val()` on the input field followed by `timepicker('getTime')` does not return the new time.

I stumbled on this while writing unit tests for my app. I'm attaching a failing test case.
