### PR TITLE
Add lockToInterval option

### DIFF
--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -557,6 +557,12 @@ if (typeof jQuery !== 'undefined') {
 
                 if (time && time.getMinutes && widget._isValidTime(i, time)) {
                     time = normalize(time);
+                     if (i.options.interval !== null && i.options.lockToInterval === true) {
+                        time.setSeconds(0);
+                        time.setMilliseconds(0);
+                        time.setHours(time.getMinutes() > (60 - Math.ceil(i.options.interval/2)) ? (time.getHours() === 23 ? 0 : time.getHours()+1) : time.getHours());
+                        time.setMinutes((parseInt((time.getMinutes() + (i.options.interval/2))/i.options.interval)  * i.options.interval) % 60);
+                    }
                     i.selectedTime = time;
                     i.element.val(i.format(time, i.options.timeFormat));
 


### PR DESCRIPTION
lockToInterval causes entered times to snap to the closest interval, based on a start of 0 minutes.

So, if you define an interval of 15, and lockToInterval is true, the following will happen:
Entry: 803, Results in: 8:00 AM
Entry: 808, Results in: 8:15 AM
Entry: 2357, Results in 12:00 AM