### PR TITLE
Fix Change Events triggering on Init (#102)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.10"
+    - "6"
 install:
     - npm install grunt-cli -g
     - npm install

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
         ' * <%= pkg.description %>\n' +
         ' *\n' +
         ' * Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;' +
-        ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %>\n' +
+        ' Licensed <%= _.map(pkg.licenses, "type").join(", ") %>\n' +
         ' */\n' +
         '\n'
     },

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -272,8 +272,8 @@
                             i.close();
                         }
                     });
-                }).bind('change.timepicker', function() {
-                    if (i.closed()) {
+                }).bind('change.timepicker', function(event, time) {
+                    if (typeof time === 'undefined' && i.closed()) {
                         i.setTime($.fn.timepicker.parseTime(i.element.val()));
                     }
                 });
@@ -583,6 +583,7 @@
                 // custom change event and change callback
                 // TODO: add documentation about this event
                 if (previous !== null || i.selectedTime !== null) {
+                    i.element.trigger('change', [time]);
                     i.element.trigger('time-change', [time]);
                     if ($.isFunction(i.options.change)) {
                         i.options.change.apply(i.element, [time]);

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -432,8 +432,14 @@ if (typeof jQuery !== 'undefined') {
                     widget.ui.css({ paddingRight: paddingRight + 40 }).addClass('ui-no-scrollbar');
                 }
 
-                // position
-                widget.container.css('top', parseInt(widget.container.css('top'), 10) + i.element.outerHeight());
+                // Check if timepicker would be off-screen and position accordingly.
+                var _widgetHeight = widget.container.height();
+                var _widgetCssTop = parseInt(widget.container.css('top'), 10);
+
+                if(widget.container.offset().top > ($(window).scrollTop() + $(window).height() - _widgetHeight))
+                  widget.container.css('top', _widgetCssTop - _widgetHeight);
+                else
+                  widget.container.css('top', _widgetCssTop + i.element.outerHeight());
 
                 widget.instance = i;
 

--- a/jquery.timepicker.js
+++ b/jquery.timepicker.js
@@ -272,8 +272,8 @@
                             i.close();
                         }
                     });
-                }).bind('change.timepicker', function(event, time) {
-                    if (typeof time === 'undefined' && i.closed()) {
+                }).bind('change.timepicker', function() {
+                    if (i.closed()) {
                         i.setTime($.fn.timepicker.parseTime(i.element.val()));
                     }
                 });
@@ -589,7 +589,6 @@
                 // custom change event and change callback
                 // TODO: add documentation about this event
                 if (previous !== null || i.selectedTime !== null) {
-                    i.element.trigger('change', [time]);
                     i.element.trigger('time-change', [time]);
                     if ($.isFunction(i.options.change)) {
                         i.options.change.apply(i.element, [time]);

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
     "jquery": ">= 1.4.3"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-clean": "0.4.1",
-    "grunt-contrib-compress": "0.5.0",
-    "grunt-contrib-concat": "0.1.3",
-    "grunt-contrib-connect": "0.3.0",
-    "grunt-contrib-copy": "0.4.0",
-    "grunt-contrib-csslint": "0.1.1",
-    "grunt-contrib-cssmin": "0.5.0",
-    "grunt-contrib-jshint": "0.3.0",
-    "grunt-contrib-qunit": "^0.7.0",
-    "grunt-contrib-uglify": "^0.9.2"
+    "grunt": "1.x",
+    "grunt-contrib-clean": "1.x",
+    "grunt-contrib-compress": "1.x",
+    "grunt-contrib-concat": "1.x",
+    "grunt-contrib-connect": "1.x",
+    "grunt-contrib-copy": "1.x",
+    "grunt-contrib-csslint": "1.x",
+    "grunt-contrib-cssmin": "1.x",
+    "grunt-contrib-jshint": "1.x",
+    "grunt-contrib-qunit": "1.x",
+    "grunt-contrib-uglify": "1.x"
   },
   "engines": {
     "node": ">= 0.6.0"

--- a/test/test.js
+++ b/test/test.js
@@ -472,7 +472,7 @@ if (jQuery.fn.jquery < '1.4') {
 
 
 
-        module('TimePicker Event Handlers', { teardown: teardown });
+        module('TimePicker Event Handlers');
 
         test('opened/closed', function() {
             var timepicker = $('#timepicker').timepicker(),
@@ -549,21 +549,6 @@ if (jQuery.fn.jquery < '1.4') {
             });
 
             system.queue('test', function(/*next*/) { start(); }).dequeue('test');
-        });
-
-        test('change event is triggered when a time entry is selected', function() {
-            var timepicker = $('#timepicker').timepicker();
-            var instance = timepicker.timepicker();
-
-            $('#timepicker').change(function(event) {
-                equal($(event.target).val(), '01:00 PM', 'The value of the element matches expected value.');
-                ok(true, 'The handler for change event was executed');
-                start();
-            });
-
-            expect(2); stop();
-
-            instance.setTime('1300');
         });
     });
 })(jQuery);

--- a/test/test.js
+++ b/test/test.js
@@ -472,7 +472,7 @@ if (jQuery.fn.jquery < '1.4') {
 
 
 
-        module('TimePicker Event Handlers');
+        module('TimePicker Event Handlers', { teardown: teardown });
 
         test('opened/closed', function() {
             var timepicker = $('#timepicker').timepicker(),
@@ -549,6 +549,21 @@ if (jQuery.fn.jquery < '1.4') {
             });
 
             system.queue('test', function(/*next*/) { start(); }).dequeue('test');
+        });
+
+        test('change event is triggered when a time entry is selected', function() {
+            var timepicker = $('#timepicker').timepicker();
+            var instance = timepicker.timepicker();
+
+            $('#timepicker').change(function(event) {
+                equal($(event.target).val(), '01:00 PM', 'The value of the element matches expected value.');
+                ok(true, 'The handler for change event was executed');
+                start();
+            });
+
+            expect(2); stop();
+
+            instance.setTime('1300');
         });
     });
 })(jQuery);


### PR DESCRIPTION
Hi,
thank you very much for this plugin, it's Amazing!

I've found that the change event is triggered when the plugin is initialised.
The problem was on line 587, where you've made a conditional statement where you check if the previous variable is Null, but the variable is Undefined.
I've also changed the OR condition to AND.

Let me know if that helped.

-----------------------------
Line 586:
                if (previous !== null && previous !== undefined && 
                    i.selectedTime !== null && i.selectedTime !== undefined) {
                    i.element.trigger('time-change', [time]);
                    if ($.isFunction(i.options.change)) {
                        i.options.change.apply(i.element, [time]);
                    }
                }
